### PR TITLE
#10 Fixed incorrect response returned due to invalid login

### DIFF
--- a/backend/src/main/kotlin/com/etchedjournal/etched/controller/EntryServiceController.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/controller/EntryServiceController.kt
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 class EntryServiceController(private val entryService: EntryService) {
 
     companion object {
-        val logger = LoggerFactory.getLogger(EntryServiceController::class.java)
+        private val logger = LoggerFactory.getLogger(EntryServiceController::class.java)
     }
 
     /**
@@ -42,7 +42,7 @@ class EntryServiceController(private val entryService: EntryService) {
     @PostMapping("")
     fun create(@RequestBody entry: EntryRequest): Entry {
         if (entry.title == null) {
-            throw BadRequestException("Title can't be null")
+            throw BadRequestException(message = "Title can't be null")
         }
 
         return entryService.create(entry.title)

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/exception/Exceptions.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/exception/Exceptions.kt
@@ -50,9 +50,16 @@ open class ClientException(
  * @param logMessage optional - specify log message
  */
 open class BadRequestException(
+        status: HttpStatus = HttpStatus.BAD_REQUEST,
         message: String = "Bad request",
         logMessage: String? = null
-) : ClientException(HttpStatus.BAD_REQUEST, message, logMessage)
+) : ClientException(status, message, logMessage) {
+    init {
+        if (!status.is4xxClientError) {
+            throw IllegalArgumentException("Supplied non-400 status $status")
+        }
+    }
+}
 
 /**
  * Exception thrown due to an invalid payload
@@ -63,7 +70,18 @@ open class BadRequestException(
 open class InvalidPayloadException(
         message: String,
         logMessage: String? = null
-) : BadRequestException(message, logMessage)
+) : BadRequestException(message = message, logMessage = logMessage)
+
+/**
+ * User is unauthorized to perform the requested action
+ *
+ * @param message message to return to the user
+ * @param logMessage optional - specify log message
+ */
+open class UnauthorizedException(
+    message: String,
+    logMessage: String? = null
+) : BadRequestException(HttpStatus.UNAUTHORIZED, message, logMessage)
 
 /**
  * Exception thrown when user is forbidden to access requested data
@@ -106,3 +124,12 @@ open class ServerException(
         }
     }
 }
+
+/**
+ * Exception thrown when backend receives unexpected response from auth server
+ *
+ * @param logMessage optional - specify log message
+ */
+class AuthServerException(
+    logMessage: String? = null
+): ServerException(HttpStatus.SERVICE_UNAVAILABLE, logMessage = logMessage)

--- a/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/KeycloakOpenIdKeycloakApi.kt
+++ b/backend/src/main/kotlin/com/etchedjournal/etched/service/impl/KeycloakOpenIdKeycloakApi.kt
@@ -2,23 +2,32 @@ package com.etchedjournal.etched.service.impl
 
 import com.etchedjournal.etched.dto.LoginResponse
 import com.etchedjournal.etched.dto.UserInfo
-import org.springframework.util.LinkedMultiValueMap
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
-import org.springframework.web.client.RestTemplate
 import com.etchedjournal.etched.service.OpenIdConnectApi
+import com.etchedjournal.etched.service.exception.AuthServerException
+import com.etchedjournal.etched.service.exception.UnauthorizedException
 import org.keycloak.OAuth2Constants
 import org.keycloak.adapters.springsecurity.client.KeycloakClientRequestFactory
 import org.keycloak.adapters.springsecurity.client.KeycloakRestTemplate
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
-
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestTemplate
 
 /**
  * [OpenIdConnectApi] implementation for a confidential Keycloak client.
  */
-class KeycloakOpenIdKeycloakApi(baseUrl: String, private val clientId: String, private val clientSecret: String): OpenIdConnectApi {
+class KeycloakOpenIdKeycloakApi(
+    baseUrl: String,
+    private val clientId: String,
+    private val clientSecret: String
+) : OpenIdConnectApi {
 
     private val loginUrl: String
     private val logoutUrl: String
@@ -38,11 +47,43 @@ class KeycloakOpenIdKeycloakApi(baseUrl: String, private val clientId: String, p
         const val OPENID_LOGOUT_URL = OPENID_PROTOCOL + "/logout"
         const val OPENID_USERINFO_URL = OPENID_PROTOCOL + "/userinfo"
 
+        private val logger: Logger = LoggerFactory.getLogger(KeycloakOpenIdKeycloakApi::class.java)
+
+        /**
+         * Utility to create an [HttpHeaders] object with [accessToken] in the Authorization header
+         *
+         * @param accessToken token to write in Authorization header
+         */
         @JvmStatic
         private fun authHeaders(accessToken: String): HttpHeaders {
             val headers = HttpHeaders()
             headers.set(HttpHeaders.AUTHORIZATION, accessToken)
             return headers
+        }
+
+        /**
+         * Utility to throw ServerException when server receives unexpected response from keycloak
+         *
+         * This handles cases where the restTemplate raises an exception but we know that it's not
+         * due to a backend error. For example, an invalid [login] attempt raises an exception
+         * because the * backend gets a 401 status code. In that case the value for expected
+         * would be [HttpStatus.UNAUTHORIZED]. If we ever received something else, we raise an
+         * [AuthServerException]
+         *
+         * @param expected expected http code
+         * @param httpClientErrorException exception raised by rest template operation
+         * @throws AuthServerException when exception is not of the expected http code
+         */
+        @JvmStatic
+        private fun handleNonExpectedCode(
+            expected: HttpStatus,
+            httpClientErrorException: HttpClientErrorException
+        ) {
+            if (httpClientErrorException.statusCode != expected) {
+                // UNEXPECTED!!!
+                logger.error("Uncaught exception {}", httpClientErrorException)
+                throw AuthServerException("Received unexpected response from keycloak")
+            }
         }
     }
 
@@ -63,8 +104,15 @@ class KeycloakOpenIdKeycloakApi(baseUrl: String, private val clientId: String, p
         payload.add(FORM_PASSWORD, password)
         payload.add(OAuth2Constants.GRANT_TYPE, OAuth2Constants.PASSWORD)
 
-        // Uses simpleRestTemplate because user is not already logged in
-        return post(loginUrl, headers, payload, LoginResponse::class.java, simpleRestTemplate)
+        try {
+            // Uses simpleRestTemplate because user is not already logged in
+            return post(loginUrl, headers, payload, LoginResponse::class.java, simpleRestTemplate)
+        } catch (e: HttpClientErrorException) {
+            handleNonExpectedCode(HttpStatus.UNAUTHORIZED, e)
+            logger.info("Login attempt failed for username='{}'", username)
+            // TODO: Should we throw UnauthorizedException or BadRequestException?
+            throw UnauthorizedException("Incorrect username/password")
+        }
     }
 
     override fun logout(accessToken: String, refreshToken: String): Any {
@@ -77,8 +125,7 @@ class KeycloakOpenIdKeycloakApi(baseUrl: String, private val clientId: String, p
     }
 
     override fun userInfo(accessToken: String): UserInfo {
-        val headers = HttpHeaders()
-        headers.set(HttpHeaders.AUTHORIZATION, accessToken)
+        val headers = authHeaders(accessToken)
 
         val payload = LinkedMultiValueMap<String, String>()
         return post(userInfoUrl, headers, payload, UserInfo::class.java)
@@ -89,20 +136,20 @@ class KeycloakOpenIdKeycloakApi(baseUrl: String, private val clientId: String, p
     }
 
     private fun <T> post(
-            url: String,
-            headers: HttpHeaders,
-            payload: MultiValueMap<String, String>,
-            responseType: Class<T>
+        url: String,
+        headers: HttpHeaders,
+        payload: MultiValueMap<String, String>,
+        responseType: Class<T>
     ): T {
         return post(url, headers, payload, responseType, keycloakRestTemplate)
     }
 
     private fun <T> post(
-            url: String,
-            headers: HttpHeaders,
-            payload: MultiValueMap<String, String>,
-            responseType: Class<T>,
-            restTemplate: RestTemplate
+        url: String,
+        headers: HttpHeaders,
+        payload: MultiValueMap<String, String>,
+        responseType: Class<T>,
+        restTemplate: RestTemplate
     ): T {
         headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
 


### PR DESCRIPTION
Fixed by catching the exception thrown by the rest template, logging a message, and
returning an appropriate error response.